### PR TITLE
Update trbs.py with modify method

### DIFF
--- a/src/vlinder/test_modify.py
+++ b/src/vlinder/test_modify.py
@@ -1,0 +1,32 @@
+# Ignore PEP8 protected-access to client class | pylint: disable=W0212
+"""
+This module contains all tests for the modify method in the trbs.py file
+"""
+import pytest
+from pathlib import Path
+import numpy as np
+from src.vlinder.trbs import TheResponsibleBusinessSimulator
+
+
+@pytest.mark.parametrize(
+    "arg, expected_result",
+    [
+        (['theme_weight','Planet',1000],1000),        
+        (['key_output_weight','Accidents reduction',2000],2000),        
+        (['scenario_weight','Base case',3000],3000),        
+    ],
+)
+
+def test_modify(arg, expected_result):
+    """
+    This function tests the modify method in the TheResponsibleBusinessSimulator class
+    :param arg: the list to be checked
+    :param expected_result: the expected content of this list
+    """
+    case = TheResponsibleBusinessSimulator(Path.cwd() / "src/vlinder/data", "xlsx", "beerwiser")
+    case.build()    
+    case.modify(arg[0], arg[1], arg[2])
+    master_key = arg[0].split('_weight')[0] + 's'
+    index = np.where(case.input_dict[master_key] == arg[1])[0][0]
+    result = case.input_dict[arg[0]][index]
+    assert result == expected_result

--- a/src/vlinder/trbs.py
+++ b/src/vlinder/trbs.py
@@ -8,6 +8,7 @@ from vlinder.evaluate import Evaluate
 from vlinder.appreciate import Appreciate
 from vlinder.visualize import Visualize
 
+import numpy as np
 
 class TheResponsibleBusinessSimulator:
     """
@@ -77,3 +78,20 @@ class TheResponsibleBusinessSimulator:
         if not self.exporter:
             self.exporter = CaseExporter(output_path, self.name, self.dataframe_dict)
         self.exporter.create_template_for_requested_format(requested_format)
+
+    def modify(self, input_dict_key, element_key, new_value):
+        """
+        This function changes the value of one of the inputs in the input_dict.
+        The following keys in input_dict are currently supported: key_output_weight, scenario_weight, theme_weight
+        :param input_dict_key: the key in the input_dict for which the value should be changed. 
+        :param element_key: is the name of the element within the input_dict_key to be changed
+        :param new_value: is the new value to be changed to
+        """
+        supported_input_keys = ['key_output_weight', 'scenario_weight', 'theme_weight']
+        if input_dict_key not in supported_input_keys:
+            raise ValueError("Please specify one of", supported_input_keys)
+        master_key = self.input_dict_key.split('_weight')[0] + 's'
+        index = np.where(self.input_dict[master_key] == element_key)
+        old_value = self.input_dict[input_dict_key][index]
+        self.input_dict[input_dict_key][index] = new_value
+        print(f"The weight for {element_key} in {input_dict_key} is changed from {old_value[0]} to {new_value}.")


### PR DESCRIPTION
To change weights of key outputs, themes or scenarios, one can now use "modify", which is a method in TheResponsibleBusinessSimulator class. We still need to discuss whether we should have a separate "aggregate" function that just processes the changed weights into a new weighted sum.